### PR TITLE
add carcass crawler classes

### DIFF
--- a/src/containers/classes/Classes.jsx
+++ b/src/containers/classes/Classes.jsx
@@ -11,6 +11,8 @@ export default function ClassOptions(props) {
 
   const [advancedClassesDisplay, setAdvancedClassesDisplay] = useState(false)
 
+  const [carcassClassesDisplay, setCarcassClassesDisplay] = useState(false)
+
   const listClassOptions = (classType) => {
     const classData = classOptionsData.filter((characterClass) => {
       return characterClass.category === classType
@@ -42,12 +44,25 @@ export default function ClassOptions(props) {
           value='Advanced Classes'
           checkedCondition={advancedClassesDisplay}
           callback={() => setAdvancedClassesDisplay(!advancedClassesDisplay)}
+        ></Checkbox>&nbsp;
+        Carcass Crawler Classes
+        <Checkbox
+          value='Carcass Crawler Classes'
+          checkedCondition={carcassClassesDisplay}
+          callback={() => setCarcassClassesDisplay(!carcassClassesDisplay)}
         ></Checkbox>
       </h3>
 
       {advancedClassesDisplay && (
         <CharacterClasses
           classType='advanced'
+          callback={listClassOptions}
+        ></CharacterClasses>
+      )}
+
+      {carcassClassesDisplay && (
+        <CharacterClasses
+          classType='carcass'
           callback={listClassOptions}
         ></CharacterClasses>
       )}

--- a/src/css/App.css
+++ b/src/css/App.css
@@ -953,6 +953,7 @@ a {
 
 .class-description--summary {
   margin-left: 10px;
+  white-space: pre-wrap;
 }
 
 .class-description--prime-reqs {

--- a/src/data/classOptionsData.jsx
+++ b/src/data/classOptionsData.jsx
@@ -7,7 +7,7 @@ const classOptionsData = [
     multiplePrimeReqs: false,
     hd: 8,
     maxLevel: 14,
-    armour: 'Any leather, chainmail, plate, shields',
+    armour: 'any leather, chainmail, plate, shields',
     weapons: 'any',
     languages: 'Alignment, Common',
     description:
@@ -599,7 +599,7 @@ const classOptionsData = [
     abilities: [
       'Awareness',
       'Divine Magic',
-      'Foragin and Hunting',
+      'Foraging and Hunting',
       'Limited Possessions',
       'Pursuit',
       'Surprise Attack',
@@ -638,6 +638,298 @@ const classOptionsData = [
     link: 'https://oldschoolessentials.necroticgnome.com/srd/',
     arcane: false,
     divine: false
+  },
+  {
+    name: 'Acolyte',
+    category: 'carcass',
+    requirements: null,
+    primeReqs: ['wisdom'],
+    hd: 6,
+    maxLevel: 14,
+    armour: 'any leather, chainmail, plate, shields',
+    weapons: 'only blunt weapons',
+    languages:
+      'Alignment, Common',
+    description:
+      'Acolytes are adventurers who have sworn to serve a deity. They are trained for battle and can channel the power of their deity.',
+    savingThrows: [11, 12, 14, 16, 15],
+    nextLevel: 1500,
+    abilities: [
+      'Bless',
+      'Detect Magic',
+      'Divine Magic',
+      'Know Alignment',
+      'Purify',
+      'Rally',
+      'Turn Undead'
+    ],
+    link: 'https://necroticgnome.com/products/carcass-crawler-issue-1',
+    arcane: false,
+    divine: true
+  },
+  {
+    name: 'Gargantua',
+    category: 'carcass',
+    requirements: 'Minimum 9 constitution, minimum 9 strength',
+    primeReqs: ['constitution','strength'],
+    checkPrimeReqRequirements: function(abilityScore1, abilityScore2) {
+      if (abilityScore1 >= 13 && abilityScore2 >= 16) {
+        return 10
+      }
+
+      if (abilityScore1 >= 13 && abilityScore2 >= 13) {
+        return 5
+      }
+
+      return 0
+    },
+    hd: 10,
+    maxLevel: 10,
+    armour: 'any leather, chainmail, plate, shields',
+    weapons: 'any, can wield two-handed melee weapon with one hand',
+    languages:
+      'Alignment, Common',
+    description:
+      'Known as the “Big Siblings of Human-kind,” gargantuas are demihumans who stand about 7½’ tall and weigh 550 pounds. Gargantuas typically live among or near humans, though some prefer to establish their own communities in the wilderness. They are known as powerful warriors with a strong resistance to every kind of hardship. Gargantuas also have a reputation for being slow-witted and literal-minded that is not entirely deserved, though it is true that they lack subtlety when compared to their smaller kin. They can be steadfast allies or unyielding foes.',
+    savingThrows: [8, 9, 10, 13, 12],
+    nextLevel: 2500,
+    abilities: [
+      'Open Doors',
+      'Rock Throwing'
+    ],
+    link: 'https://necroticgnome.com/products/carcass-crawler-issue-1',
+    arcane: false,
+    divine: false
+  },
+  {
+    name: 'Goblin',
+    category: 'carcass',
+    requirements: 'Minimum 9 dexterity',
+    primeReqs: ['dexterity','strength'],
+    checkPrimeReqRequirements: function(abilityScore1, abilityScore2) {
+      if (abilityScore1 >= 16 && abilityScore2 >= 16) {
+        return 10
+      }
+
+      if (abilityScore1 >= 13 || abilityScore2 >= 13) {
+        return 5
+      }
+
+      return 0
+    },
+    hd: 10,
+    maxLevel: 10,
+    armour: 'any leather, chainmail, plate, shields',
+    weapons: 'any appropriate to size',
+    languages:
+      'Alignment, Common, Goblin, the language of wolves',
+    description:
+      'Goblins are short demihumans standing between 3’ and 3½’ tall. They possess skin ranging in colour from yellow to orange to red (and everything in between), while their eyes are usually reddish in hue and are visible even in the dark. Though many goblins live underground, not all do so, especially those most likely to interact with humans and join adventuring parties. Goblins can be somewhat surly and resentful when interacting with other beings, or even their own kin, like bugbears and hobgoblins. These attitudes are only heightened by the fact that many goblins—though not all—are aligned with Chaos.',
+    savingThrows: [8, 9, 10, 13, 12],
+    nextLevel: 2000,
+    abilities: [
+      'Defensive Bonus',
+      'Detect Construction Tricks',
+      'Infravision',
+      'Stealth',
+      'Wolf Affinity'
+    ],
+    link: 'https://necroticgnome.com/products/carcass-crawler-issue-1',
+    arcane: false,
+    divine: false
+  },
+  {
+    name: 'Hephaestan',
+    category: 'carcass',
+    requirements: 'Minimum 9 charisma, minimum 9 constitution',
+    primeReqs: ['intelligence','wisdom'],
+    checkPrimeReqRequirements: function(abilityScore1, abilityScore2) {
+      if (abilityScore1 >= 16 && abilityScore2 >= 13) {
+        return 10
+      }
+
+      if (abilityScore1 >= 13 && abilityScore2 >= 13) {
+        return 5
+      }
+
+      return 0
+    },
+    hd: 6,
+    maxLevel: 10,
+    armour: 'leather, chainmail, shields',
+    weapons: 'any',
+    languages:
+      'Alignment, Common, Hephaestan',
+    description:
+      'Hephaestans are a race of tall (6’), thin demihumans with angular features and pointed ears. Some sages claim they are relatives of elves, hailing from a distant land or even another world. For their part, hephaestans are tight lipped on the subject of their origins. Coldly rational and seemingly without emotion, the hephaestans are highly skilled in the use of mental powers, which they employ instead of magic. Despite their aloofness, hephaestans get along well with most intelligent races.',
+    savingThrows: [12, 13, 13, 15, 15],
+    nextLevel: 3000,
+    abilities: [
+      'Listening at Doors',
+      'Mental Powers (ESP, gestalt, healing trance, mind control, mind shield, telepathy)',
+      'Neuropressure'
+    ],
+    link: 'https://necroticgnome.com/products/carcass-crawler-issue-1',
+    arcane: false,
+    divine: false
+  },
+  {
+    name: 'Kineticist',
+    category: 'carcass',
+    requirements: null,
+    primeReqs: ['dexterity','wisdom'],
+    checkPrimeReqRequirements: function(abilityScore1, abilityScore2) {
+      if (abilityScore1 >= 16 && abilityScore2 >= 16) {
+        return 10
+      }
+
+      if (abilityScore1 >= 13 && abilityScore2 >= 13) {
+        return 5
+      }
+
+      return 0
+    },
+    hd: 6,
+    maxLevel: 14,
+    armour: 'none',
+    weapons: 'any',
+    languages:
+      'Alignment, Common',
+    description:
+      'Kineticists are masters of mind over matter, their rigorous physical and mental training focusing on the manipulation of internal kinetic force. This force can be harnessed to accelerate motion and hone reactions or can be projected outward to affect distant objects.\nThe ability to manipulate kinetic force may be awakened spontaneously or may be learned from a master. Either way, it is often the case that this power runs in families.',
+    savingThrows: [13, 14, 13, 16, 15],
+    nextLevel: 2000,
+    abilities: [
+      'Mental Defense',
+      'Mental Powers (accelerated motion, control density, crush life, kinetic fist, kinetic leap, kinetic shield, kinetic wave, telekinetic attack, throw weapon)',
+      'Neuropressure'
+    ],
+    link: 'https://necroticgnome.com/products/carcass-crawler-issue-1',
+    arcane: false,
+    divine: false
+  },
+  {
+    name: 'Mage',
+    category: 'carcass',
+    requirements: null,
+    primeReqs: ['intelligence','wisdom'],
+    checkPrimeReqRequirements: function(abilityScore1, abilityScore2) {
+      if (abilityScore1 >= 16 && abilityScore2 >= 13) {
+        return 10
+      }
+
+      if (abilityScore1 >= 13 && abilityScore2 >= 13) {
+        return 5
+      }
+
+      return 0
+    },
+    hd: 6,
+    maxLevel: 14,
+    armour: 'none',
+    weapons: 'dagger, short sword, staff, sword',
+    languages:
+      'Alignment, Common',
+    description:
+      'Mages are adventurers who study the secrets of deep magic, making them powerful allies.',
+    savingThrows: [12, 13, 12, 15, 14],
+    nextLevel: 2800,
+    abilities: [
+      'Arcane Magic',
+      'Detect Magic',
+      'Healing',
+      'Mage Armour',
+      'Mage’s Staff',
+      'Open/Close',
+      'Rally/Fear',
+      'Read Magic',
+      'Scribing Scrolls',
+      'Suggestion'
+    ],
+    link: 'https://necroticgnome.com/products/carcass-crawler-issue-1',
+    arcane: true,
+    divine: false
+  },
+  {
+    name: 'Phase Elf',
+    category: 'carcass',
+    requirements: 'Minimum 9 intelligence',
+    primeReqs: ['intelligence','strength'],
+    checkPrimeReqRequirements: function(abilityScore1, abilityScore2) {
+      if (abilityScore1 >= 16 && abilityScore2 >= 13) {
+        return 10
+      }
+
+      if (abilityScore1 >= 13 && abilityScore2 >= 13) {
+        return 5
+      }
+
+      return 0
+    },
+    hd: 6,
+    maxLevel: 10,
+    armour: 'any leather, chainmail, plate, shields / none',
+    weapons: 'any / dagger',
+    languages:
+      'Alignment, Common, Elvish, Doppelgänger, Dragon, Pixie',
+    description:
+      'Phase elves are slender, fey demihumans with pointed ears. They typically weigh about 120 pounds and are between 5½ and 6 feet tall. Their hair tends to be violet or silver and their eyes are either pure black or pure white—without an iris or pupil (see Dual Persona). Phase elves originate from an alternate dimension which is inaccessible to other races, and about which they never speak.',
+    savingThrows: [12, 13, 13, 15, 15],
+    nextLevel: 2800,
+    abilities: [
+      'Arcane Magic',
+      'Detect Secret Doors',
+      'Dual Persona',
+      'Immunity to Ghoul Paralysis',
+      'Infravision',
+      'Listening at Doors'
+    ],
+    link: 'https://necroticgnome.com/products/carcass-crawler-issue-2',
+    arcane: true,
+    arcaneSpells: true,
+    divine: false
+  },
+  {
+    name: 'Wood Elf',
+    category: 'carcass',
+    requirements: 'Minimum 9 dexterity, minimum 9 intelligence',
+    primeReqs: ['dexterity','wisdom'],
+    checkPrimeReqRequirements: function(abilityScore1, abilityScore2) {
+      if (abilityScore1 >= 16 && abilityScore2 >= 13) {
+        return 10
+      }
+
+      if (abilityScore1 >= 13 && abilityScore2 >= 13) {
+        return 5
+      }
+
+      return 0
+    },
+    hd: 6,
+    maxLevel: 10,
+    armour: 'leather, shields',
+    weapons: 'any',
+    languages:
+      'Alignment, Common, Elvish, Bugbear, Dryad, Gnoll',
+    description:
+      'Wood elves are slender, fey demihumans with pointed ears. They typically weigh about 110 pounds and are between 5 and 5½ feet tall. Wood elves dwell in hidden, treetop settlements in deep forests, and are seldom seen by humans. They are reclusive and defend their homelands against trespassers. Like druids, wood elves worship the force of nature and the myriad deities that personify it.',
+    savingThrows: [12, 13, 13, 15, 15],
+    nextLevel: 3000,
+    abilities: [
+      'Awareness',
+      'Detect Secret Doors',
+      'Divine Magic',
+      'Foraging and Hunting',
+      'Hiding',
+      'Immunity to Ghoul Paralysis',
+      'Infravision',
+      'Listening at Doors',
+      'Missile Attack Bonus'
+    ],
+    link: 'https://necroticgnome.com/products/carcass-crawler-issue-2',
+    arcane: false,
+    divine: true,
+    druidSpells: true,
   }
 ]
 

--- a/src/utilities/i18n.jsx
+++ b/src/utilities/i18n.jsx
@@ -18,7 +18,7 @@ i18n
           Roll: 'Roll',
           Tavern: 'Tavern',
           AppDescription:
-            'Designed for use with <0>Old School Essentials</0>. Advanced Fantasy classes included with the permission of Necrotic Gnome.',
+            'Designed for use with <0>Old School Essentials</0>. Additional classes included with the permission of Necrotic Gnome & James Maliszewski.',
           CreatedBy: '<0>Created by EvilTables</0>',
           abilityScoreNames: {
             strength: 'Strength',
@@ -45,7 +45,7 @@ i18n
           Roll: 'Würfeln',
           Tavern: 'Taverne',
           AppDescription:
-            'Entwickelt für die Verwendung mit <0>Old School Essentials</0>. OSE Advanced Fantasy-Klassen enthalten mit Genehmigung von Necrotic Gnome.',
+            'Entwickelt für die Verwendung mit <0>Old School Essentials</0>. Zusätzlich Klassen enthalten mit Genehmigung von Necrotic Gnome & James Maliszewski.',
           CreatedBy: '<0>Erstellt von EvilTables</0>',
           abilityScoreNames: {
             strength: 'Stärke',


### PR DESCRIPTION
Adds classes from Carcass Crawler Issue 1 and Issue 2.

Permission granted by Gavin Norman of Necrotic Gnome and James Maliszewski of Grognardia to use the classes information.
![gavin-permission](https://user-images.githubusercontent.com/15150173/214928436-87645459-03a9-497b-bb2c-1a1ffed27431.png)
![james-permission](https://user-images.githubusercontent.com/15150173/214928132-143d5fe5-731e-4b56-ae55-0849d89d5bcd.png)


## Implementation

- For Acolyte, the skill is written as `"Turn undead"` instead of `"Turning the Undead"`. This is because the latter is used as a heading for describing the skill procedure, while the former is the name of the skill.
- Add `white-space: pre-wrap` to `.class-description--summary` to support line breaks in Kineticist description.
- Kineticist Mental Powers combined into one. Not sure if should be separate.
- Followed convention for omitting `"any appropriate to size"` for armor. Otherwise, this would be necessary for Gargantua and Goblin. Perhaps it may be better to use `"Any appropriate to size, including shields"` as written.
- Gargantua has a reverse order prime requisites check: 16 STR and 13 CON. The order of prime requisites is defined as constitution before strength.
- Goblin has a prime requisite check for either ability score above 13, using OR logic.

## Suggestions (not implemented)

- We should follow capitalization convention as written. For example, `"Weapons: Any"` rather than `"Weapons: any"`.
- We should follow armor restrictions as written, such as `"Armour: Any, including shields"` rather than `"Armour: any leather, chainmail, plate, shields'"`.
- We should also follow Requirements abbreviation of attributes as written. For example, `"Requirements: Minimum CON 9, minimum STR 9"`. However, this will require refactoring as the requirements check performs a substring search for `constitution` in the requirements string.
- We should change skills that were originally headings to skill names. For example, `"Turn Undead"` rather than `"Turning the Undead"`

## Future Work

- We should add Necromancer (my favorite class), and other classes from Carcass Crawler Issue 0 (Kickstarter Exclusive). There is a list [here](https://www.mapandkey.net/blog/a-comprehensive-list-of-ose-classes) in addition to 3rd party classes by Map & Key. We could also add Dolmenwood classes, though I see that you have already implemented that in dolmenwood_vite. My inclination is to limit scope to classes published by Necrotic Gnome (list of [official classes](https://www.reddit.com/r/osr/comments/ylucod/list_of_all_ose_classes_and_where_to_ask_for/iv0mti9/)).