### PR TITLE
--add: necromancer

### DIFF
--- a/src/containers/class-details/SpellSelection.jsx
+++ b/src/containers/class-details/SpellSelection.jsx
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types'
 import {
   magicUserSpells,
   druidSpells,
-  illusionistSpells
+  illusionistSpells,
+  necromancerSpells
 } from '../../data/spells'
 import { chooseRandomItem } from '../../utilities/utilities'
 import Option from '../../components/general/Option'
@@ -29,6 +30,10 @@ export default function SpellSelection({
       randomSpell = chooseRandomItem(illusionistSpells)
     }
 
+    if (characterClass.necromancerSpells) {
+      randomSpell = chooseRandomItem(necromancerSpells)
+    }
+
     setSpellSelected(randomSpell)
     setCharacterStatistics((prevState) => {
       return { ...prevState, spell: randomSpell, hasSpells: true }
@@ -52,6 +57,10 @@ export default function SpellSelection({
       spellList = illusionistSpells
     }
 
+    if (characterClass.necromancerSpells) {
+      spellList = necromancerSpells
+    }
+
     return spellList.map((spell, index) => {
       return <Option key={index} value={spell.toString()}></Option>
     })
@@ -70,7 +79,8 @@ export default function SpellSelection({
     characterClass.arcaneSpells ||
     characterClass.divineSpells ||
     characterClass.illusionistSpells ||
-    characterClass.druidSpells
+    characterClass.druidSpells ||
+    characterClass.necromancerSpells
   )
 
   return (

--- a/src/data/classOptionsData.jsx
+++ b/src/data/classOptionsData.jsx
@@ -546,6 +546,29 @@ const classOptionsData = [
     divine: false
   },
   {
+    name: 'Necromancer',
+    category: 'advanced',
+    requirements: 'Minimum 9 wisdom',
+    primeReqs: ['intelligence'],
+    hd: 4,
+    maxLevel: 14,
+    armour: 'none',
+    weapons: 'dagger, staff (optional)',
+    languages:
+      'Alignment, Common',
+    description:
+      'Necromancers are adventurers who study the arcane arts of death and the undead. Through this study, they have learned to cast magic spells.',
+    savingThrows: [13, 14, 13, 16, 15],
+    nextLevel: 2500,
+    abilities: [
+      'Arcane Magic',
+    ],
+    link: 'https://www.drivethrurpg.com/product/414657/OldSchool-Essentials-The-Necromancer',
+    arcane: true,
+    necromancerSpells: true,
+    divine: false
+  },
+  {
     name: 'Paladin',
     category: 'advanced',
     requirements: 'Minimum 9 charisma',

--- a/src/data/spells.jsx
+++ b/src/data/spells.jsx
@@ -38,3 +38,18 @@ export const illusionistSpells = [
   "Spook",
   "Wall of Fog"
 ];
+
+export const necromancerSpells = [
+  "Chill Touch",
+  "Command Dead",
+  "Corpse Visage",
+  "Decay",
+  "Deathlight",
+  "Detect Undead",
+  "Marionette",
+  "Pass Undead",
+  "Protection from Evil",
+  "Read Magic",
+  "Skull Speech",
+  "Undead Servitor"
+];


### PR DESCRIPTION
Necromancer is official playtest content produced by Necrotic Gnome. It is designed for OSE Classic and Advanced Fantasy. The content *will* be published in its final form in a future OSE book. We can sync any changes with upcoming releases. Currently, the content is v0.2.

We should consider adding this class as it will increase exposure and help generate playtest feedback.

This PR adds the Necromancer class and spell list.