### PR TITLE
Add export for descending armour class

### DIFF
--- a/src/constants/constants.jsx
+++ b/src/constants/constants.jsx
@@ -8,6 +8,9 @@ export const greenSuccess = '#09b341'
 export const CHARACTER_SHEET_PURIST_URL =
   'https://matthewfee.github.io/OSECharacterServer/public/CharacterSheetTemplate7.pdf'
 
+export const CHARACTER_SHEET_PURIST_DAC_URL =
+  '/src/img/DAC.pdf'
+
 export const CHARACTER_SHEET_UNDERGROUND_URL =
   'https://matthewfee.github.io/OSECharacterServer/public/Underground10.pdf'
 


### PR DESCRIPTION
This fulfills #41, although it is currently incomplete.  I don't know where I should upload the template to, so as of right now this PR references the DAC template under `/src/img`.  However, I didn't want to create legal concerns, so I did not actually include the template file in this PR.  An upload and a change of URL will have to occur in order to make this PR functional.

As for now, this can be tested by placing the purist DAC PDF from Necrotic Gnome in the `/src/img` directory.

Please let me know what needs to be done in order to include the template properly.