### PR TITLE
fix: clear spells when class changes or character is rerolled

### DIFF
--- a/src/containers/class-details/SpellSelection.jsx
+++ b/src/containers/class-details/SpellSelection.jsx
@@ -77,11 +77,11 @@ export default function SpellSelection({
 
   const handleSpellChange = (event) => {
     setSpellSelected(event.target.value)
-    setCharacterStatistics({
-      ...setCharacterStatistics,
+    setCharacterStatistics((prevState) => ({
+      ...prevState,
       spell: event.target.value,
       hasSpells: true
-    })
+    }))
   }
 
   const hasSpells = !!(

--- a/src/pages/CharacterGenerator.jsx
+++ b/src/pages/CharacterGenerator.jsx
@@ -192,6 +192,11 @@ export default function CharacterGenerator() {
     setCharacter({ ...character, id: newID });
     setRollButtonHover(false);
     setCharacterClass({ name: null, primeReqs: [] });
+    setCharacterStatistics((prevState) => ({
+      ...prevState,
+      spell: null,
+      hasSpells: false,
+    }));
     setCharacterRolled(true);
 
     setAbilityScores(defaultAbilityScoresState);
@@ -205,6 +210,11 @@ export default function CharacterGenerator() {
     );
 
     setCharacterClass(characterClass);
+    setCharacterStatistics((prevState) => ({
+      ...prevState,
+      spell: null,
+      hasSpells: false,
+    }));
   };
 
   let characterMenuStyle = characterRolled ? {} : { display: "none" };


### PR DESCRIPTION
Closes #57

## Problem
A spell rolled for a caster (Magic-User, Illusionist, Druid, Necromancer, Runesmith) carried over to subsequent non-caster characters. e.g. roll a Magic-User with Sleep, then build a Fighter, and the Fighter's sheet/PDF still shows "Spells: Sleep".

## Cause
`spell` and `hasSpells` live in `characterStatistics` state. Neither `changeCharacterClass` nor `rollCharacter` reset them, and the sheet/PDF gate spell display only on `characterStatistics.hasSpells`. The stale values persisted across class switches and new characters.

## Fix
- Reset `spell: null, hasSpells: false` in `changeCharacterClass`.
- Same reset in `rollCharacter` so a fresh character never inherits the prior one's spell.
- Fix `handleSpellChange` in SpellSelection.jsx, which spread the setter function (`...setCharacterStatistics`) instead of prior state. This wiped `hitPoints`/`armourClass`/`unarmouredAC` whenever a spell was picked from the dropdown.

## Testing
- Magic-User + Sleep, then switch to Fighter: spell no longer shows. 
- `npm run build` passes.